### PR TITLE
4 concurrency

### DIFF
--- a/src/main/java/HW/concurrency/enums/EnrichType.java
+++ b/src/main/java/HW/concurrency/enums/EnrichType.java
@@ -1,0 +1,15 @@
+package HW.concurrency.enums;
+
+public enum EnrichType {
+  MSISDN("msisdn");
+
+  private final String mapField;
+
+  EnrichType(String mapField){
+    this.mapField = mapField;
+  }
+
+  public String getMapField(){
+    return mapField;
+  }
+}

--- a/src/main/java/HW/concurrency/enums/EnrichType.java
+++ b/src/main/java/HW/concurrency/enums/EnrichType.java
@@ -1,15 +1,23 @@
 package HW.concurrency.enums;
 
+import java.util.List;
+
 public enum EnrichType {
-  MSISDN("msisdn");
+  MSISDN("msisdn", List.of("firstName", "lastName"));
 
   private final String mapField;
+  private final List<String> targetFields;
 
-  EnrichType(String mapField){
+  EnrichType(String mapField, List<String> targetFields){
     this.mapField = mapField;
+    this.targetFields = targetFields;
   }
 
   public String getMapField(){
     return mapField;
+  }
+
+  public List<String> getTargetFields(){
+    return targetFields;
   }
 }

--- a/src/main/java/HW/concurrency/models/Message.java
+++ b/src/main/java/HW/concurrency/models/Message.java
@@ -4,6 +4,7 @@ import HW.concurrency.enums.EnrichType;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -29,5 +30,14 @@ public class Message {
     answer += "Following enrich types: " + message.enrichTypes.stream().map(Enum::toString).collect(Collectors.joining(" "));
     answer += "Following content:\n" + message.content.entrySet().stream().map(Object::toString).collect(Collectors.joining("\n"));
     return answer;
+  }
+
+  public static Map<String, String> generateRandomContent(){
+    Random random = new Random();
+    Map<String, String> content = new HashMap<>();
+    content.put("message", Integer.toString(random.nextInt(-1000, 1000)));
+    content.put("page", Integer.toString(random.nextInt(-1000, 1000)));
+    content.put("actionNumber", Integer.toString(random.nextInt(-1000, 1000)));
+    return content;
   }
 }

--- a/src/main/java/HW/concurrency/models/Message.java
+++ b/src/main/java/HW/concurrency/models/Message.java
@@ -2,14 +2,32 @@ package HW.concurrency.models;
 
 import HW.concurrency.enums.EnrichType;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public class Message {
   private Map<String, String> content;
-  private Set<EnrichType> enrichTypes;
+  public final Set<EnrichType> enrichTypes;
+
+  public Message(Map<String, String> content, Set<EnrichType> enrichTypes) {
+    this.content = content;
+    this.enrichTypes = enrichTypes;
+  }
+
+  public Map<String, String> getContent() {
+    return new HashMap<>(content);
+  }
+
+  public void setContent(Map<String, String> content) {
+    this.content = content;
+  }
 
   public static String toString(Message message){
-    return "";
+    String answer = "Message with:\n";
+    answer += "Following enrich types: " + message.enrichTypes.stream().map(Enum::toString).collect(Collectors.joining(" "));
+    answer += "Following content:\n" + message.content.entrySet().stream().map(Object::toString).collect(Collectors.joining("\n"));
+    return answer;
   }
 }

--- a/src/main/java/HW/concurrency/models/Message.java
+++ b/src/main/java/HW/concurrency/models/Message.java
@@ -1,0 +1,15 @@
+package HW.concurrency.models;
+
+import HW.concurrency.enums.EnrichType;
+
+import java.util.Map;
+import java.util.Set;
+
+public class Message {
+  private Map<String, String> content;
+  private Set<EnrichType> enrichTypes;
+
+  public static String toString(Message message){
+    return "";
+  }
+}

--- a/src/main/java/HW/concurrency/models/Message.java
+++ b/src/main/java/HW/concurrency/models/Message.java
@@ -18,11 +18,15 @@ public class Message {
   }
 
   public Map<String, String> getContent() {
-    return new HashMap<>(content);
+    synchronized (this){
+      return new HashMap<>(content);
+    }
   }
 
   public void setContent(Map<String, String> content) {
-    this.content = content;
+    synchronized (this) {
+      this.content = new HashMap<>(content);
+    }
   }
 
   public static String toString(Message message){

--- a/src/main/java/HW/concurrency/models/enrich/EnrichAction.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichAction.java
@@ -1,0 +1,4 @@
+package HW.concurrency.models.enrich;
+
+public class EnrichAction {
+}

--- a/src/main/java/HW/concurrency/models/enrich/EnrichAction.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichAction.java
@@ -8,5 +8,5 @@ import java.util.Map;
 
 public interface EnrichAction {
   EnrichType enrichType();
-  void enrich(UserRepository userRepository, Message message);
+  Map<String, String> enrich(UserRepository userRepository, Message message);
 }

--- a/src/main/java/HW/concurrency/models/enrich/EnrichAction.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichAction.java
@@ -1,4 +1,12 @@
 package HW.concurrency.models.enrich;
 
-public class EnrichAction {
+import HW.concurrency.enums.EnrichType;
+import HW.concurrency.models.Message;
+import HW.concurrency.models.user.UserRepository;
+
+import java.util.Map;
+
+public interface EnrichAction {
+  EnrichType enrichType();
+  void enrich(UserRepository userRepository, Message message);
 }

--- a/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
@@ -17,6 +17,9 @@ public class EnrichMSISDN implements EnrichAction{
 
   @Override
   public Map<String, String> enrich(UserRepository userRepository, Message message) {
+    if (userRepository == null || message == null) {
+      throw new IllegalArgumentException("Null parameters were provided to enrich");
+    }
     String filterField = enrichType().getMapField();
     Map<String, String> input = message.getContent();
     if (!input.containsKey(filterField)) {

--- a/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
@@ -1,0 +1,4 @@
+package HW.concurrency.models.enrich;
+
+public class EnrichMSISDN {
+}

--- a/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
@@ -1,4 +1,37 @@
 package HW.concurrency.models.enrich;
 
-public class EnrichMSISDN {
+import HW.concurrency.enums.EnrichType;
+import HW.concurrency.models.Message;
+import HW.concurrency.models.user.User;
+import HW.concurrency.models.user.UserRepository;
+
+import java.util.List;
+import java.util.Map;
+
+public class EnrichMSISDN implements EnrichAction{
+
+  @Override
+  public EnrichType enrichType() {
+    return EnrichType.MSISDN;
+  }
+
+  @Override
+  public void enrich(UserRepository userRepository, Message message) {
+    String filterField = enrichType().getMapField();
+    Map<String, String> input = message.getContent();
+    if (!input.containsKey(filterField)) {
+      throw new RuntimeException("Provided message doesn't has necessary field");
+    }
+    User user = userRepository.findByField(filterField, input.get(filterField)); // will throw error if can't find
+    for (String field : fieldsToEdit()) {
+      input.put(field, user.getInfoAtField(field)); // will throw error if no such field
+    }
+    //Message newMessage = new Message(input, message.enrichTypes);
+    message.setContent(input);
+    //return message;
+  }
+
+  private List<String> fieldsToEdit() {
+    return enrichType().getTargetFields();
+  }
 }

--- a/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichMSISDN.java
@@ -16,7 +16,7 @@ public class EnrichMSISDN implements EnrichAction{
   }
 
   @Override
-  public void enrich(UserRepository userRepository, Message message) {
+  public Map<String, String> enrich(UserRepository userRepository, Message message) {
     String filterField = enrichType().getMapField();
     Map<String, String> input = message.getContent();
     if (!input.containsKey(filterField)) {
@@ -27,8 +27,8 @@ public class EnrichMSISDN implements EnrichAction{
       input.put(field, user.getInfoAtField(field)); // will throw error if no such field
     }
     //Message newMessage = new Message(input, message.enrichTypes);
-    message.setContent(input);
-    //return message;
+    //message.setContent(input);
+    return input;
   }
 
   private List<String> fieldsToEdit() {

--- a/src/main/java/HW/concurrency/models/enrich/EnrichService.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichService.java
@@ -19,7 +19,7 @@ public class EnrichService {
     if (enrichActionList == null || enrichActionList.size() == 0 || userRepository == null) {
       throw new IllegalArgumentException("EnrichService has requirements for its values: " +
               " not null enrichActionList " + Boolean.toString(enrichActionList == null) +
-              " not empty enrichActionList " + Boolean.toString(enrichActionList.size() == 0) +
+              " not empty enrichActionList " + Boolean.toString(enrichActionList == null || enrichActionList.size() == 0) +
               " not null userRepository " + Boolean.toString(userRepository == null));
     }
     this.enrichActionList = enrichActionList;

--- a/src/main/java/HW/concurrency/models/enrich/EnrichService.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichService.java
@@ -1,0 +1,20 @@
+package HW.concurrency.models.enrich;
+
+import HW.concurrency.models.Message;
+import HW.concurrency.models.user.UserRepository;
+
+import java.util.List;
+
+public class EnrichService {
+  private final List<EnrichAction> enrichActionList;
+  private final UserRepository userRepository;
+
+  public EnrichService(List<EnrichAction> enrichActionList, UserRepository userRepository) {
+    this.enrichActionList = enrichActionList;
+    this.userRepository = userRepository;
+  }
+
+  public Message enrich(Message message){
+    return message;
+  }
+}

--- a/src/main/java/HW/concurrency/models/enrich/EnrichService.java
+++ b/src/main/java/HW/concurrency/models/enrich/EnrichService.java
@@ -1,20 +1,48 @@
 package HW.concurrency.models.enrich;
 
+import HW.concurrency.enums.EnrichType;
 import HW.concurrency.models.Message;
 import HW.concurrency.models.user.UserRepository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class EnrichService {
+  private final Map<EnrichType, List<EnrichAction>> enrichActionMap;
   private final List<EnrichAction> enrichActionList;
   private final UserRepository userRepository;
 
   public EnrichService(List<EnrichAction> enrichActionList, UserRepository userRepository) {
+    if (enrichActionList == null || enrichActionList.size() == 0 || userRepository == null) {
+      throw new IllegalArgumentException("EnrichService has requirements for its values: " +
+              " not null enrichActionList " + Boolean.toString(enrichActionList == null) +
+              " not empty enrichActionList " + Boolean.toString(enrichActionList.size() == 0) +
+              " not null userRepository " + Boolean.toString(userRepository == null));
+    }
     this.enrichActionList = enrichActionList;
     this.userRepository = userRepository;
+    this.enrichActionMap = enrichActionList.stream().collect(Collectors.groupingBy(EnrichAction::enrichType));
   }
 
-  public Message enrich(Message message){
-    return message;
+  public void enrich(Message message){
+    if (message == null) {
+      throw new IllegalArgumentException("Tried to enrich null");
+    }
+    synchronized (message) {
+      int enrichCounter = 0;
+      for (EnrichType enrichType : message.enrichTypes) {
+        for (EnrichAction enrichAction : enrichActionMap.getOrDefault(enrichType, List.of())) {
+          try {
+            enrichAction.enrich(userRepository, message);
+            enrichCounter += 1;
+            break;
+          } catch (RuntimeException e) {
+            System.out.println(e.getMessage());
+          }
+        }
+      }
+      System.out.printf("Out of %d enrichments to make %d were successful%n", message.enrichTypes.size(), enrichCounter);
+    }
   }
 }

--- a/src/main/java/HW/concurrency/models/user/User.java
+++ b/src/main/java/HW/concurrency/models/user/User.java
@@ -1,4 +1,23 @@
 package HW.concurrency.models.user;
 
+import java.util.Map;
+
 public class User {
+  private Map<String, String> information;
+
+  public User(Map<String, String> information) {
+    this.information = information;
+  }
+
+  public String getInfoAtField(String field) {
+    if (information.containsKey(field)) {
+      return information.get(field);
+    } else {
+      throw new IllegalArgumentException("User doesn't contain field: " + field);
+    }
+  }
+
+  public void updateInfo(String field, String value){
+    information.put(field, value);
+  }
 }

--- a/src/main/java/HW/concurrency/models/user/User.java
+++ b/src/main/java/HW/concurrency/models/user/User.java
@@ -1,0 +1,4 @@
+package HW.concurrency.models.user;
+
+public class User {
+}

--- a/src/main/java/HW/concurrency/models/user/User.java
+++ b/src/main/java/HW/concurrency/models/user/User.java
@@ -1,12 +1,13 @@
 package HW.concurrency.models.user;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class User {
   private Map<String, String> information;
 
   public User(Map<String, String> information) {
-    this.information = information;
+    this.information = new HashMap<>(information);
   }
 
   public String getInfoAtField(String field) {

--- a/src/main/java/HW/concurrency/models/user/UserRepository.java
+++ b/src/main/java/HW/concurrency/models/user/UserRepository.java
@@ -1,0 +1,6 @@
+package HW.concurrency.models.user;
+
+public interface UserRepository {
+  User findByField();
+  void updateUserByMsisdn(String msisdn, User user);
+}

--- a/src/main/java/HW/concurrency/models/user/UserRepository.java
+++ b/src/main/java/HW/concurrency/models/user/UserRepository.java
@@ -1,6 +1,6 @@
 package HW.concurrency.models.user;
 
 public interface UserRepository {
-  User findByField();
-  void updateUserByMsisdn(String msisdn, User user);
+  User findByField(String field, String value);
+  void updateUserByField(String field, String value, User user);
 }

--- a/src/main/java/HW/concurrency/models/user/UserRepository.java
+++ b/src/main/java/HW/concurrency/models/user/UserRepository.java
@@ -1,6 +1,10 @@
 package HW.concurrency.models.user;
 
 public interface UserRepository {
+
   User findByField(String field, String value);
+
   void updateUserByField(String field, String value, User user);
+
+  void addUser(User user);
 }

--- a/src/main/java/HW/concurrency/models/user/UserRepositoryWithList.java
+++ b/src/main/java/HW/concurrency/models/user/UserRepositoryWithList.java
@@ -1,13 +1,22 @@
 package HW.concurrency.models.user;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class UserRepositoryWithList implements UserRepository{
+  private List<User> users;
+
+  public UserRepositoryWithList(List<User> users) {
+    this.users = users == null ? new ArrayList<>() : users;
+  }
+
   @Override
-  public User findByField() {
+  public User findByField(String field, String value) {
     return null;
   }
 
   @Override
-  public void updateUserByMsisdn(String msisdn, User user) {
-
+  public void updateUserByField(String field, String value, User user) {
+    User locatedUser = findByField(field, value);
   }
 }

--- a/src/main/java/HW/concurrency/models/user/UserRepositoryWithList.java
+++ b/src/main/java/HW/concurrency/models/user/UserRepositoryWithList.java
@@ -1,0 +1,13 @@
+package HW.concurrency.models.user;
+
+public class UserRepositoryWithList implements UserRepository{
+  @Override
+  public User findByField() {
+    return null;
+  }
+
+  @Override
+  public void updateUserByMsisdn(String msisdn, User user) {
+
+  }
+}

--- a/src/main/java/HW/concurrency/models/user/UserRepositoryWithList.java
+++ b/src/main/java/HW/concurrency/models/user/UserRepositoryWithList.java
@@ -1,22 +1,40 @@
 package HW.concurrency.models.user;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class UserRepositoryWithList implements UserRepository{
-  private List<User> users;
+  private CopyOnWriteArrayList<User> users;
 
   public UserRepositoryWithList(List<User> users) {
-    this.users = users == null ? new ArrayList<>() : users;
+    this.users = new CopyOnWriteArrayList<>(users != null ? users : List.of());
   }
 
   @Override
   public User findByField(String field, String value) {
-    return null;
+    Optional<User> locatedUser = users.parallelStream().filter(user -> user.getInfoAtField(field).equals(value)).findFirst();
+    if (locatedUser.isPresent()){
+      return locatedUser.get();
+    } else {
+      throw new IllegalArgumentException("Can't locate user with field: " + field + " value: " + value);
+    }
   }
 
   @Override
   public void updateUserByField(String field, String value, User user) {
-    User locatedUser = findByField(field, value);
+    try {
+      User locatedUser = findByField(field, value);
+      users.set(users.indexOf(locatedUser), user);
+    } catch (IllegalArgumentException e) {
+      System.out.println("No user to update");
+    }
+  }
+
+  @Override
+  public void addUser(User user) {
+    if (!users.contains(user)) {
+      users.add(user);
+    }
   }
 }

--- a/src/test/java/HW/concurrency/enums/EnrichTypeTest.java
+++ b/src/test/java/HW/concurrency/enums/EnrichTypeTest.java
@@ -1,0 +1,23 @@
+package HW.concurrency.enums;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnrichTypeTest {
+
+  @Test
+  void getMapField() {
+    for (EnrichType enrichType : EnrichType.values()) {
+      Assertions.assertNotNull(enrichType.getMapField());
+    }
+  }
+
+  @Test
+  void getTargetFields() {
+    for (EnrichType enrichType : EnrichType.values()) {
+      Assertions.assertNotNull(enrichType.getTargetFields());
+    }
+  }
+}

--- a/src/test/java/HW/concurrency/models/MessageTest.java
+++ b/src/test/java/HW/concurrency/models/MessageTest.java
@@ -46,6 +46,6 @@ class MessageTest {
   @Test
   void testToString() {
     generateTestMessage(null, null);
-    Assertions.assertDoesNotThrow(() -> testMessage.toString());
+    Assertions.assertNotNull(Message.toString(testMessage));
   }
 }

--- a/src/test/java/HW/concurrency/models/MessageTest.java
+++ b/src/test/java/HW/concurrency/models/MessageTest.java
@@ -1,0 +1,51 @@
+package HW.concurrency.models;
+
+import HW.concurrency.enums.EnrichType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MessageTest {
+  private static Message testMessage;
+
+  private static void generateTestMessage(Map<String, String> content, Set<EnrichType> enrichTypes){
+    if (testMessage != null) {
+      return;
+    }
+    if (content == null) {
+      content = Message.generateRandomContent();
+    }
+    if (enrichTypes == null) {
+      enrichTypes = Set.of(EnrichType.MSISDN);
+    }
+    testMessage = new Message(content, enrichTypes);
+  }
+
+  @Test
+  void getContent() {
+    generateTestMessage(null, null);
+    Map<String, String> content = testMessage.getContent();
+    content.clear();
+    Assertions.assertTrue(content.isEmpty() && !testMessage.getContent().isEmpty());
+  }
+
+  @Test
+  void setContent() {
+    generateTestMessage(null, null);
+    Message messageCopy = new Message(testMessage.getContent(), testMessage.enrichTypes);
+    Map<String, String> emptyContent = new HashMap<>();
+    messageCopy.setContent(emptyContent);
+    Assertions.assertTrue(messageCopy.getContent().isEmpty());
+  }
+
+  @Test
+  void testToString() {
+    generateTestMessage(null, null);
+    Assertions.assertDoesNotThrow(() -> testMessage.toString());
+  }
+}

--- a/src/test/java/HW/concurrency/models/enrich/EnrichMSISDNTest.java
+++ b/src/test/java/HW/concurrency/models/enrich/EnrichMSISDNTest.java
@@ -1,0 +1,21 @@
+package HW.concurrency.models.enrich;
+
+import HW.concurrency.enums.EnrichType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnrichMSISDNTest {
+
+  @Test
+  void enrichType() {
+    EnrichAction enrichMSISDN = new EnrichMSISDN();
+    EnrichTestDefault.enrichType(enrichMSISDN, EnrichType.MSISDN);
+  }
+
+  @Test
+  void enrich() {
+    EnrichAction enrichMSISDN = new EnrichMSISDN();
+    EnrichTestDefault.enrich(enrichMSISDN);
+  }
+}

--- a/src/test/java/HW/concurrency/models/enrich/EnrichServiceTest.java
+++ b/src/test/java/HW/concurrency/models/enrich/EnrichServiceTest.java
@@ -1,0 +1,204 @@
+package HW.concurrency.models.enrich;
+
+import HW.concurrency.enums.EnrichType;
+import HW.concurrency.models.Message;
+import HW.concurrency.models.user.User;
+import HW.concurrency.models.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnrichServiceTest {
+
+  private static boolean checkListContainsAnother(List<Map<String, String>> list1, List<Map<String, String>> list2){
+    List<Map<String,String>> unMatchedRecords = list1.parallelStream().filter(map ->
+            list2.parallelStream().noneMatch(compareMap ->
+                    map.entrySet().stream().noneMatch(value1 ->
+                            compareMap.entrySet().stream().noneMatch(value2 ->
+                                    (value1.getKey().equals(value2.getKey()) &&
+                                            value1.getValue().equals(value2.getValue()))))))
+            .toList();
+
+    //list1.containsAll(list2);
+    return unMatchedRecords.isEmpty();
+  }
+
+  @Test
+  void enrich() {
+    Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new EnrichService(null, null));
+
+    EnrichType enrichType = EnrichType.MSISDN;
+    String uniField = enrichType.getMapField();
+
+    UserRepository userRepository = EnrichTestDefault.emptyUserRepository();
+    Map<String, String> information1 = new HashMap<>();
+    Map<String, String> information2 = new HashMap<>();
+    String uni1 = "UNIQUE1";
+    String uni2 = "UNIQUE2";
+    String uni3 = "UNIQUE3";
+    String val1 = "Purrrr";
+    String val2 = "Rahr";
+    information1.put(uniField, uni1);
+    information2.put(uniField, uni2);
+    for (String field : enrichType.getTargetFields()) {
+      information1.put(field, val1);
+      information2.put(field, val2);
+    }
+    User user1 = new User(information1);
+    User user2 = new User(information2);
+    userRepository.addUser(user1);
+    userRepository.addUser(user2);
+
+    List<Message> messageList = List.of(
+            new Message(
+                    Map.of(uniField, uni1, "content", "Queque", "action", "Fly"),
+                    Set.of(enrichType)), // test that can enrich
+            new Message(
+                    Map.of(uniField, uni1, "content", "Queque", enrichType.getTargetFields().get(0), "Fly"),
+                    Set.of(enrichType)), // test that overwrites fields
+            new Message(
+                    Map.of(uniField, uni1, "content", "Queque", "action", "Fly"),
+                    Set.of()), // test that won't change if message indicates so
+            new Message(
+                    Map.of(uniField, uni2, "content", "Queque", "action", "Fly"),
+                    Set.of(enrichType)), // test that differentiates between users
+            new Message(
+                    Map.of(uniField, uni3, "content", "Queque", "action", "Fly"),
+                    Set.of(enrichType)) // test that works when refers to unknown user
+    );
+    List<Map<String, String>> messageMapsBeforeTest = messageList.stream().map(Message::getContent).toList();
+    /*
+    List<Map<String, String>> messageMapsBeforeTest = List.of(
+            new HashMap<>(Map.of(uniField, uni1, "content", "Queque", "action", "Fly")),
+            new HashMap<>(Map.of(uniField, uni1, "content", "Queque", enrichType.getTargetFields().get(0), "Fly")),
+            new HashMap<>(Map.of(uniField, uni1, "content", "Queque", "action", "Fly")),
+            new HashMap<>(Map.of(uniField, uni2, "content", "Queque", "action", "Fly")),
+            new HashMap<>(Map.of(uniField, uni3, "content", "Queque", "action", "Fly"))
+    );
+    */
+    List<Map<String, String>> messageMapsToTest = messageMapsBeforeTest
+            .stream()
+            .map(e -> (Map<String, String>) new HashMap<>(e))
+            .toList();
+    messageMapsToTest.get(0).putAll(information1);
+    messageMapsToTest.get(1).putAll(information1);
+    messageMapsToTest.get(3).putAll(information2);
+    List<Message> enrichedMessages = new ArrayList<>();
+
+    EnrichService enrichService = new EnrichService(List.of(new EnrichMSISDN()), userRepository);
+
+    for (Message message : messageList) {
+      enrichedMessages.add(enrichService.enrich(message));
+    }
+    List<Map<String, String>> enrichedMessageMaps = enrichedMessages.stream().map(Message::getContent).toList();
+
+    Assertions.assertTrue(checkListContainsAnother(
+            messageMapsBeforeTest,
+            messageList.stream().map(Message::getContent).toList()));
+    Assertions.assertTrue(checkListContainsAnother(
+            messageMapsToTest,
+            enrichedMessageMaps));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> enrichService.enrich(null));
+  }
+
+  @Test
+  void enrichConcurrent() {
+    Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new EnrichService(null, null));
+
+    EnrichType enrichType = EnrichType.MSISDN;
+    String uniField = enrichType.getMapField();
+
+    UserRepository userRepository = EnrichTestDefault.emptyUserRepository();
+    Map<String, String> information1 = new HashMap<>();
+    Map<String, String> information2 = new HashMap<>();
+    String uni1 = "UNIQUE1";
+    String uni2 = "UNIQUE2";
+    String uni3 = "UNIQUE3";
+    String val1 = "Purrrr";
+    String val2 = "Rahr";
+    information1.put(uniField, uni1);
+    information2.put(uniField, uni2);
+    for (String field : enrichType.getTargetFields()) {
+      information1.put(field, val1);
+      information2.put(field, val2);
+    }
+    User user1 = new User(information1);
+    User user2 = new User(information2);
+    userRepository.addUser(user1);
+    userRepository.addUser(user2);
+
+    List<Message> messageList = List.of(
+            new Message(
+                    Map.of(uniField, uni1, "content", "Queque", "action", "Fly"),
+                    Set.of(enrichType)), // test that can enrich
+            new Message(
+                    Map.of(uniField, uni1, "content", "Queque", enrichType.getTargetFields().get(0), "Fly"),
+                    Set.of(enrichType)), // test that overwrites fields
+            new Message(
+                    Map.of(uniField, uni1, "content", "Queque", "action", "Fly"),
+                    Set.of()), // test that won't change if message indicates so
+            new Message(
+                    Map.of(uniField, uni2, "content", "Queque", "action", "Fly"),
+                    Set.of(enrichType)), // test that differentiates between users
+            new Message(
+                    Map.of(uniField, uni3, "content", "Queque", "action", "Fly"),
+                    Set.of(enrichType)) // test that works when refers to unknown user
+    );
+    List<Map<String, String>> messageMapsBeforeTest = messageList.stream().map(Message::getContent).toList();
+    /*
+    List<Map<String, String>> messageMapsBeforeTest = List.of(
+            new HashMap<>(Map.of(uniField, uni1, "content", "Queque", "action", "Fly")),
+            new HashMap<>(Map.of(uniField, uni1, "content", "Queque", enrichType.getTargetFields().get(0), "Fly")),
+            new HashMap<>(Map.of(uniField, uni1, "content", "Queque", "action", "Fly")),
+            new HashMap<>(Map.of(uniField, uni2, "content", "Queque", "action", "Fly")),
+            new HashMap<>(Map.of(uniField, uni3, "content", "Queque", "action", "Fly"))
+    );
+    */
+    List<Map<String, String>> messageMapsToTest = messageMapsBeforeTest
+            .stream()
+            .map(e -> (Map<String, String>) new HashMap<>(e))
+            .toList();
+    messageMapsToTest.get(0).putAll(information1);
+    messageMapsToTest.get(1).putAll(information1);
+    messageMapsToTest.get(3).putAll(information2);
+    // to make its actual state be only in test thread
+    List<Message> enrichedMessages = new CopyOnWriteArrayList<>();
+
+    EnrichService enrichService = new EnrichService(List.of(new EnrichMSISDN()), userRepository);
+
+    // concurrent process
+    ExecutorService executorService = Executors.newFixedThreadPool(messageList.size());
+    CountDownLatch latch = new CountDownLatch(messageList.size());
+    for (Message message : messageList) {
+      executorService.submit(() -> {
+        enrichedMessages.add(enrichService.enrich(message));
+        latch.countDown();
+      });
+    }
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      System.out.println("Test was interrupted during concurrent process");
+    }
+
+    // test of successful work
+    List<Map<String, String>> enrichedMessageMaps = enrichedMessages.stream().map(Message::getContent).toList();
+
+    Assertions.assertTrue(checkListContainsAnother(
+            messageMapsBeforeTest,
+            messageList.stream().map(Message::getContent).toList()));
+    Assertions.assertTrue(checkListContainsAnother(
+            messageMapsToTest,
+            enrichedMessageMaps));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> enrichService.enrich(null));
+  }
+}

--- a/src/test/java/HW/concurrency/models/enrich/EnrichTestDefault.java
+++ b/src/test/java/HW/concurrency/models/enrich/EnrichTestDefault.java
@@ -7,16 +7,13 @@ import HW.concurrency.models.user.UserRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 public class EnrichTestDefault {
 
   public static UserRepository emptyUserRepository(){
     UserRepository userRepository = new UserRepository() {
-      private List<User> users;
+      private List<User> users = new ArrayList<>();
 
       @Override
       public User findByField(String field, String value) {

--- a/src/test/java/HW/concurrency/models/enrich/EnrichTestDefault.java
+++ b/src/test/java/HW/concurrency/models/enrich/EnrichTestDefault.java
@@ -1,0 +1,68 @@
+package HW.concurrency.models.enrich;
+
+import HW.concurrency.enums.EnrichType;
+import HW.concurrency.models.Message;
+import HW.concurrency.models.user.User;
+import HW.concurrency.models.user.UserRepository;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class EnrichTestDefault {
+
+  public static UserRepository emptyUserRepository(){
+    UserRepository userRepository = new UserRepository() {
+      private List<User> users;
+
+      @Override
+      public User findByField(String field, String value) {
+        Optional<User> locatedUser = users.parallelStream().filter(user -> user.getInfoAtField(field).equals(value)).findFirst();
+        if (locatedUser.isPresent()){
+          return locatedUser.get();
+        } else {
+          throw new IllegalArgumentException("Can't locate user with field: " + field + " value: " + value);
+        }
+      }
+
+      @Override
+      public void updateUserByField(String field, String value, User user) {
+        return;
+      }
+
+      @Override
+      public void addUser(User user) {
+        users.add(user);
+      }
+    };
+    return userRepository;
+  }
+
+  public static void enrichType(EnrichAction enrichActionToTest, EnrichType enrichTypeToAssert) {
+    Assertions.assertTrue(enrichActionToTest.enrichType() == enrichTypeToAssert);
+  }
+
+  public static void enrich(EnrichAction enrichActionToTest) {
+    String debugValue = "MeowMeow";
+    UserRepository userRepository = emptyUserRepository();
+    Map<String, String> information = new HashMap<>();
+    information.put(enrichActionToTest.enrichType().getMapField(), debugValue);
+    for (String field : enrichActionToTest.enrichType().getTargetFields()) {
+      information.put(field, debugValue);
+    }
+
+    userRepository.addUser(new User(information));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> enrichActionToTest.enrich(null, null));
+    Assertions.assertThrows(RuntimeException.class, () -> enrichActionToTest.enrich(userRepository, new Message(null, null)));
+    Assertions.assertThrows(RuntimeException.class, () -> enrichActionToTest.enrich(userRepository, new Message(new HashMap<>(), null)));
+    Assertions.assertTrue(enrichActionToTest.enrich(
+            userRepository,
+            new Message(
+                    Map.of(enrichActionToTest.enrichType().getMapField(), debugValue),
+                    null))
+            .equals(information));
+  }
+}

--- a/src/test/java/HW/concurrency/models/user/UserRepositoryTestDefault.java
+++ b/src/test/java/HW/concurrency/models/user/UserRepositoryTestDefault.java
@@ -1,0 +1,33 @@
+package HW.concurrency.models.user;
+
+import org.junit.jupiter.api.Assertions;
+
+import java.util.Map;
+
+class UserRepositoryTestDefault {
+
+  public static void findByField(UserRepository userRepositoryToTest){
+    String debugField = "MeowMeow";
+    User user = new User(Map.of(debugField, debugField));
+    userRepositoryToTest.addUser(user);
+    Assertions.assertThrows(RuntimeException.class,
+            () -> userRepositoryToTest.findByField(debugField.toUpperCase(), debugField));
+    Assertions.assertEquals(user, userRepositoryToTest.findByField(debugField, debugField));
+  }
+
+  public static void updateUserByField(UserRepository userRepositoryToTest){
+    String debugField = "MeowMeow";
+    User user = new User(Map.of(debugField, debugField));
+    userRepositoryToTest.addUser(user);
+    User newUser = new User(Map.of(debugField, debugField, debugField.toUpperCase(), debugField));
+    userRepositoryToTest.updateUserByField(debugField, debugField, newUser);
+    Assertions.assertEquals(newUser, userRepositoryToTest.findByField(debugField, debugField));
+  }
+
+  public static void addUser(UserRepository userRepositoryToTest){
+    String debugField = "MeowMeow";
+    User user = new User(Map.of(debugField, debugField));
+    userRepositoryToTest.addUser(user);
+    Assertions.assertDoesNotThrow(() -> userRepositoryToTest.findByField(debugField, debugField));
+  }
+}

--- a/src/test/java/HW/concurrency/models/user/UserRepositoryTestDefault.java
+++ b/src/test/java/HW/concurrency/models/user/UserRepositoryTestDefault.java
@@ -2,6 +2,7 @@ package HW.concurrency.models.user;
 
 import org.junit.jupiter.api.Assertions;
 
+import java.util.HashMap;
 import java.util.Map;
 
 class UserRepositoryTestDefault {
@@ -10,17 +11,21 @@ class UserRepositoryTestDefault {
     String debugField = "MeowMeow";
     User user = new User(Map.of(debugField, debugField));
     userRepositoryToTest.addUser(user);
-    Assertions.assertThrows(RuntimeException.class,
+
+    Assertions.assertThrows(IllegalArgumentException.class,
             () -> userRepositoryToTest.findByField(debugField.toUpperCase(), debugField));
     Assertions.assertEquals(user, userRepositoryToTest.findByField(debugField, debugField));
   }
 
   public static void updateUserByField(UserRepository userRepositoryToTest){
     String debugField = "MeowMeow";
+    Assertions.assertDoesNotThrow(() -> userRepositoryToTest.updateUserByField(debugField, debugField, new User(new HashMap<>())));
+
     User user = new User(Map.of(debugField, debugField));
     userRepositoryToTest.addUser(user);
     User newUser = new User(Map.of(debugField, debugField, debugField.toUpperCase(), debugField));
     userRepositoryToTest.updateUserByField(debugField, debugField, newUser);
+
     Assertions.assertEquals(newUser, userRepositoryToTest.findByField(debugField, debugField));
   }
 
@@ -28,6 +33,7 @@ class UserRepositoryTestDefault {
     String debugField = "MeowMeow";
     User user = new User(Map.of(debugField, debugField));
     userRepositoryToTest.addUser(user);
+
     Assertions.assertDoesNotThrow(() -> userRepositoryToTest.findByField(debugField, debugField));
   }
 }

--- a/src/test/java/HW/concurrency/models/user/UserRepositoryWithListTest.java
+++ b/src/test/java/HW/concurrency/models/user/UserRepositoryWithListTest.java
@@ -1,0 +1,26 @@
+package HW.concurrency.models.user;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserRepositoryWithListTest {
+
+  @Test
+  void findByField() {
+    UserRepository userRepository = new UserRepositoryWithList(null);
+    UserRepositoryTestDefault.findByField(userRepository);
+  }
+
+  @Test
+  void updateUserByField() {
+    UserRepository userRepository = new UserRepositoryWithList(null);
+    UserRepositoryTestDefault.updateUserByField(userRepository);
+  }
+
+  @Test
+  void addUser() {
+    UserRepository userRepository = new UserRepositoryWithList(null);
+    UserRepositoryTestDefault.addUser(userRepository);
+  }
+}

--- a/src/test/java/HW/concurrency/models/user/UserTest.java
+++ b/src/test/java/HW/concurrency/models/user/UserTest.java
@@ -1,0 +1,29 @@
+package HW.concurrency.models.user;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.AreaAveragingScaleFilter;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+
+  @Test
+  void getInfoAtField() {
+    String debugValue = "Meoooowww";
+    User user = new User(Map.of(debugValue, debugValue));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> user.getInfoAtField(debugValue.toUpperCase()));
+    Assertions.assertEquals(user.getInfoAtField(debugValue), debugValue);
+  }
+
+  @Test
+  void updateInfo() {
+    String debugValue = "Meoooowww";
+    User user = new User(Map.of(debugValue, debugValue));
+    Assertions.assertThrows(IllegalArgumentException.class, () -> user.getInfoAtField(debugValue.toUpperCase()));
+    user.updateInfo(debugValue.toUpperCase(), debugValue);
+    Assertions.assertEquals(user.getInfoAtField(debugValue.toUpperCase()), debugValue);
+  }
+}


### PR DESCRIPTION
Это было довольно тяжко.
Свою идею с дефолтными тестами я в итоге реализовал через класс с несколькими static методами.
Чтобы некоторые вещи затестить я создавал пустышки, когда тестировалось что-то несвязанное с пустышкой, но она была необходима.
С UserRepository я в итоге решил не делать обязательную уникальность по каким-то полям, потому что вот вроде бы есть msisdn, который работает на основе поля "msisdn", но появится потом lol, который будет ориентироваться на поле "oops". В итоге надо собирать все enum значения и создавать уникальность по всему, что они там хотят. Это странно и неправильно.
Создал типа тест End-to-End в проверке service. Там есть многопоточная версия и не многопоточная. Но в них не включена еще параллельное изменение в UserRepository, работа с копиями сообщения (но там и синхронизация, и копирование, так что должно быть нормально).
А ~Main~ файл теперь не создавал вообще. Его функции тесты выполняют.
Очень помогло, когда правил баги, что можно запустить debug на классе с тестами и оно пройдет по ним (причем параллельно:D).